### PR TITLE
Feature/person serie history controller

### DIFF
--- a/src/main/java/edu/lorsenmarek/backend/config/InstantJSONConfig.java
+++ b/src/main/java/edu/lorsenmarek/backend/config/InstantJSONConfig.java
@@ -1,0 +1,45 @@
+package edu.lorsenmarek.backend.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class InstantSerializerConfig {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneOffset.UTC);
+    private static final StdSerializer<Instant> INSTANT_SERIALIZER = new StdSerializer<Instant>(Instant.class) {
+        @Override
+        public void serialize(Instant instant, JsonGenerator jg, SerializerProvider serializerProvider) throws IOException {
+            jg.writeString(FORMATTER.format(instant));
+        }
+    };
+    private static final StdDeserializer<Instant> INSTANT_DESERIALIZER = new StdDeserializer<Instant>(Instant.class) {
+        @Override
+        public Instant deserialize(JsonParser jp, DeserializationContext deserializationContext) throws IOException, JacksonException {
+            String str = jp.getText().trim();
+            return Instant.from(FORMATTER.parse(str));
+        }
+    };
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer addInstantSerialization() {
+        return builder -> builder
+                .serializationInclusion(JsonInclude.Include.ALWAYS)
+                .serializers(INSTANT_SERIALIZER)
+                .deserializers(INSTANT_DESERIALIZER);
+    }
+}

--- a/src/main/java/edu/lorsenmarek/backend/config/InstantJSONConfig.java
+++ b/src/main/java/edu/lorsenmarek/backend/config/InstantJSONConfig.java
@@ -18,7 +18,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 @Configuration
-public class InstantSerializerConfig {
+public class InstantJSONConfig {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm:ss")
             .withZone(ZoneOffset.UTC);

--- a/src/main/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryController.java
+++ b/src/main/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryController.java
@@ -1,6 +1,5 @@
 package edu.lorsenmarek.backend.controller;
 
-import edu.lorsenmarek.backend.model.Person;
 import edu.lorsenmarek.backend.model.PersonSerieHistory;
 import edu.lorsenmarek.backend.repository.PersonSerieHistoryRepository;
 import org.springframework.http.HttpStatus;
@@ -9,7 +8,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @Controller
 @RequestMapping("/person-serie-history")

--- a/src/main/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryController.java
+++ b/src/main/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryController.java
@@ -1,0 +1,46 @@
+package edu.lorsenmarek.backend.controller;
+
+import edu.lorsenmarek.backend.model.Person;
+import edu.lorsenmarek.backend.model.PersonSerieHistory;
+import edu.lorsenmarek.backend.repository.PersonSerieHistoryRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+@RequestMapping("/person-serie-history")
+public class PersonSerieHistoryController {
+    private final PersonSerieHistoryRepository PSHRepo;
+    public PersonSerieHistoryController(final PersonSerieHistoryRepository PSHRepo) {
+        this.PSHRepo = PSHRepo;
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<List<PersonSerieHistory>> getPersonHistory(
+            @PathVariable("id") Integer id
+    ) {
+        var result = PSHRepo.findByPerson(id);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("")
+    public ResponseEntity<?> saveHistory(@RequestBody PersonSerieHistory PSHToAdd) {
+        PSHRepo.save(PSHToAdd);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{personId}/{serieId}")
+    public ResponseEntity<?> deleteHistory(
+            @PathVariable(value = "personId") Integer personId,
+            @PathVariable(value = "serieId") Integer serieId
+    ){
+        if(PSHRepo.deleteByIds(personId, serieId) == 0) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+}

--- a/src/test/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryControllerTest.java
+++ b/src/test/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryControllerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PersonSerieHistoryControllerTest {
+  
+}

--- a/src/test/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryControllerTest.java
+++ b/src/test/java/edu/lorsenmarek/backend/controller/PersonSerieHistoryControllerTest.java
@@ -1,4 +1,96 @@
+package edu.lorsenmarek.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.lorsenmarek.backend.model.PersonSerieHistory;
+import edu.lorsenmarek.backend.repository.PersonSerieHistoryRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PersonSerieHistoryController.class)
 class PersonSerieHistoryControllerTest {
-  
+    final PersonSerieHistory PSHStub = PersonSerieHistory.builder()
+            .lastWatch(Instant.now())
+            .serieId(2)
+            .personId(1)
+            .instanceWatch(5)
+            .build();
+
+    @Autowired
+    private ObjectMapper mapper;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PersonSerieHistoryRepository mockPSHRepo;
+    @Test
+    void getPersonHistory_shouldCallRepoFindByPerson() throws Exception{
+        // arrange
+        when(mockPSHRepo.findByPerson(anyInt())).thenReturn(List.of(PSHStub));
+
+        // act
+        var result = mockMvc.perform(get("/person-serie-history/1"));
+
+        // assert
+        result.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].personId").value("1"));
+        verify(mockPSHRepo).findByPerson(1);
+    }
+    @Test
+    void saveHistory_shouldCallRepoSave() throws Exception {
+        // act
+        var result = mockMvc.perform(post("/person-serie-history")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(PSHStub)));
+
+        // capture
+        ArgumentCaptor<PersonSerieHistory> pshCaptor = ArgumentCaptor.forClass(PersonSerieHistory.class);
+        verify(mockPSHRepo).save(pshCaptor.capture());
+
+        // assert
+        result.andExpect(status().isOk());
+        verify(mockPSHRepo).save(any(PersonSerieHistory.class));
+        assertEquals(PSHStub.getLastWatch(), pshCaptor.getValue().getLastWatch());
+    }
+    @Nested
+    class deleteHistory {
+        @Test
+        void whenDeleteFail_shouldRespondNotFound() throws Exception{
+            // arrange
+            when(mockPSHRepo.deleteByIds(anyInt(), anyInt())).thenReturn(0);
+
+            // act
+            var result = mockMvc.perform(delete("/person-serie-history/1/2"));
+
+            // assert
+            result.andExpect(status().isNotFound());
+            verify(mockPSHRepo).deleteByIds(1,2);
+        }
+        @Test
+        void whenDeleteSucceed_shouldRespondOk() throws Exception{
+            // arrange
+            when(mockPSHRepo.deleteByIds(anyInt(), anyInt())).thenReturn(1);
+
+            // act
+            var result = mockMvc.perform(delete("/person-serie-history/1/2"));
+
+            // assert
+            result.andExpect(status().isOk());
+            verify(mockPSHRepo).deleteByIds(1,2);
+        }
+    }
 }


### PR DESCRIPTION
- [x] Feature PersonSerieHistoryController, endpoints at `/person-serie-history`
- [x] Tests suite for PersonSerieHistoryController

MariaDB only accept date of the format `yyyy-MM-dd HH:mm:ss`, but the default stringifying of Instant is formated as follow `yyyy-MM-ddTHH:mm:ss.SSSSSSSSSZ`. MariaDB reject this format, therefore i added a customization to serialize/deserialize the format in something appropriate for MariaDB (see InstantJSONConfig)